### PR TITLE
Add FastAPI stack dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,13 @@
-python-dotenv==1.0.1
-requests==2.32.3
+fastapi==0.110.0
+jinja2==3.1.4
+numpy==1.26.4
 pillow==10.4.0
+python-dotenv==1.0.1
+pytesseract==0.3.13
+pytz==2024.1
+requests==2.32.3
 sense-hat==2.6.0
 tzdata==2024.1
-pytz==2024.1
-pytesseract==0.3.13
-#opencv-python   # NÃO usar via pip — use python3-opencv do sistema (apt)
+uvicorn[standard]==0.29.0
+watchdog==4.0.1
+#opencv-python   # Do not install via pip—use the OS package instead (e.g., sudo apt-get install python3-opencv)


### PR DESCRIPTION
## Summary
- add FastAPI, Uvicorn, and supporting dependencies required by the bundled web UI
- align requirement pins with the project list and keep numpy available for cv2 integration
- document the OS-level installation path for OpenCV instead of using pip

## Testing
- pip install -r requirements.txt *(fails: ProxyError 403 when reaching the package index in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dde940c58c832fa8c01ca63728a4e1