### PR TITLE
Fix joystick handler indentation

### DIFF
--- a/main.py
+++ b/main.py
@@ -388,7 +388,7 @@ class App:
         self._show_mode_pattern(name)
 
     def handle_joystick(self, event):
-     if event.action not in ("pressed", "held"):
+        if event.action not in ("pressed", "held"):
             return
 
         delta = 0


### PR DESCRIPTION
## Summary
- correct the indentation of the joystick handler so its body is nested under the function definition

## Testing
- python main.py *(fails: ModuleNotFoundError: No module named 'RTIMU')*

------
https://chatgpt.com/codex/tasks/task_e_68decfd632b0832fb60faae1eca355e8