### PR TITLE
Replace optional chaining in web app assets

### DIFF
--- a/WebApp.py
+++ b/WebApp.py
@@ -318,8 +318,10 @@ const modeEl = document.getElementById('mode');
 const corgi = document.getElementById('corgi');
 
 function dogUrl(state, activity){
-  const mode = encodeURIComponent(state ?? 'idle');
-  let act = Number(activity ?? 0);
+  const modeValue = state !== undefined && state !== null ? state : 'idle';
+  const mode = encodeURIComponent(modeValue);
+  const activityValue = activity !== undefined && activity !== null ? activity : 0;
+  let act = Number(activityValue);
   if(!Number.isFinite(act)){ act = 0; }
   act = Math.max(0, Math.min(1, act));
   const ts = Date.now();
@@ -345,16 +347,22 @@ async function refreshOnce(){
   try{
     const r = await fetch('/api/status');
     const j = await r.json();
-    const s = j.sense;
-    tempEl.textContent = s.temperature?.toFixed?.(1) ?? '--';
-    humEl.textContent = s.humidity?.toFixed?.(1) ?? '--';
-    presEl.textContent = s.pressure?.toFixed?.(1) ?? '--';
+    const s = j && j.sense ? j.sense : {};
+    const tempValue = s.temperature;
+    const humValue = s.humidity;
+    const presValue = s.pressure;
+    tempEl.textContent = tempValue !== undefined && tempValue !== null && tempValue.toFixed ? tempValue.toFixed(1) : '--';
+    humEl.textContent = humValue !== undefined && humValue !== null && humValue.toFixed ? humValue.toFixed(1) : '--';
+    presEl.textContent = presValue !== undefined && presValue !== null && presValue.toFixed ? presValue.toFixed(1) : '--';
     senseAvail.textContent = s.available ? 'Sense HAT ✓' : 'Sense HAT unavailable';
-    motionEl.textContent = (j.motion||[]).slice(-50).join('\n');
-    modeEl.textContent = 'Mode: ' + j.mode;
+    const motionValue = j && j.motion ? j.motion : [];
+    motionEl.textContent = motionValue.slice(-50).join('\\n');
+    const modeText = j && Object.prototype.hasOwnProperty.call(j, 'mode') ? j.mode : undefined;
+    modeEl.textContent = 'Mode: ' + modeText;
 
-    const state = (j.mode||'IDLE').toLowerCase();
-    const activity = j.activity_level ?? 0;
+    const rawMode = j && j.mode ? j.mode : 'IDLE';
+    const state = rawMode.toLowerCase();
+    const activity = j && j.activity_level !== undefined && j.activity_level !== null ? j.activity_level : 0;
     setCorgi(state, activity);
   }catch(e){
     console.error(e);
@@ -366,16 +374,23 @@ async function initWS(){
     const ws = new WebSocket((location.protocol==='https:'?'wss':'ws')+'://'+location.host+'/ws');
     ws.onmessage = (ev)=>{
       const j = JSON.parse(ev.data);
-      if(j.kind==='tick'){
-        const s = j.payload;
-        tempEl.textContent = s.sense.temperature?.toFixed?.(1) ?? '--';
-        humEl.textContent = s.sense.humidity?.toFixed?.(1) ?? '--';
-        presEl.textContent = s.sense.pressure?.toFixed?.(1) ?? '--';
-        senseAvail.textContent = s.sense.available ? 'Sense HAT ✓' : 'Sense HAT unavailable';
-        motionEl.textContent = (s.motion||[]).slice(-50).join('\n');
-        modeEl.textContent = 'Mode: ' + s.mode;
-        const activity = s.activity_level ?? 0;
-        setCorgi((s.mode||'IDLE').toLowerCase(), activity);
+      if(j && j.kind==='tick'){
+        const s = j.payload ? j.payload : {};
+        const sense = s && s.sense ? s.sense : {};
+        const tempValue = sense.temperature;
+        const humValue = sense.humidity;
+        const presValue = sense.pressure;
+        tempEl.textContent = tempValue !== undefined && tempValue !== null && tempValue.toFixed ? tempValue.toFixed(1) : '--';
+        humEl.textContent = humValue !== undefined && humValue !== null && humValue.toFixed ? humValue.toFixed(1) : '--';
+        presEl.textContent = presValue !== undefined && presValue !== null && presValue.toFixed ? presValue.toFixed(1) : '--';
+        senseAvail.textContent = sense.available ? 'Sense HAT ✓' : 'Sense HAT unavailable';
+        const motionValue = s && s.motion ? s.motion : [];
+        motionEl.textContent = motionValue.slice(-50).join('\\n');
+        const modeText = s && Object.prototype.hasOwnProperty.call(s, 'mode') ? s.mode : undefined;
+        modeEl.textContent = 'Mode: ' + modeText;
+        const modeRaw = s && s.mode ? s.mode : 'IDLE';
+        const activity = s && s.activity_level !== undefined && s.activity_level !== null ? s.activity_level : 0;
+        setCorgi(modeRaw.toLowerCase(), activity);
       }
     };
     ws.onclose = ()=> setTimeout(initWS, 2000);

--- a/WebApp.py
+++ b/WebApp.py
@@ -338,9 +338,9 @@ function formatReading(value){
 }
 
 function dogUrl(state, activity){
-  const modeValue = state !== undefined && state !== null ? state : 'idle';
+  const modeValue = state != null ? state : 'idle';
   const mode = encodeURIComponent(modeValue);
-  const activityValue = activity !== undefined && activity !== null ? activity : 0;
+  const activityValue = activity != null ? activity : 0;
   let act = Number(activityValue);
   if(!Number.isFinite(act)){ act = 0; }
   act = Math.max(0, Math.min(1, act));

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>pi_productivity</title>
+  <link rel="stylesheet" href="/static/styles.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="brand">🐾 pi_productivity</div>
+    <div class="clock" id="clock"></div>
+  </header>
+
+  <main class="grid">
+    <section class="panel corgi-panel">
+      <img id="corgi" src="/dog.svg?mode=idle" alt="Dog mascot" />
+      <div class="mode" id="mode">Mode: ...</div>
+    </section>
+
+    <section class="panel measures">
+      <h3>Measures</h3>
+      <div class="measure"><span>Temp</span><b id="temp">--</b><span>°C</span></div>
+      <div class="measure"><span>Humidity</span><b id="hum">--</b><span>%</span></div>
+      <div class="measure"><span>Pressure</span><b id="pres">--</b><span>hPa</span></div>
+      <div class="availability" id="senseAvail"></div>
+    </section>
+
+    <section class="panel camera">
+      <h3>Camera</h3>
+      <img id="cam" src="/camera.jpg" alt="Camera" />
+    </section>
+
+    <section class="panel motion">
+      <h3>Motion tasks/events</h3>
+      <pre id="motion"></pre>
+    </section>
+  </main>
+
+  <footer class="foot">Made with FastAPI • Resize window to see compact mode</footer>
+  <script src="/static/app.js"></script>
+</body>
+</html>

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -1,0 +1,94 @@
+
+const clock = document.getElementById('clock');
+const tempEl = document.getElementById('temp');
+const humEl = document.getElementById('hum');
+const presEl = document.getElementById('pres');
+const senseAvail = document.getElementById('senseAvail');
+const motionEl = document.getElementById('motion');
+const modeEl = document.getElementById('mode');
+const corgi = document.getElementById('corgi');
+
+function dogUrl(state, activity){
+  const modeValue = state !== undefined && state !== null ? state : 'idle';
+  const mode = encodeURIComponent(modeValue);
+  const activityValue = activity !== undefined && activity !== null ? activity : 0;
+  let act = Number(activityValue);
+  if(!Number.isFinite(act)){ act = 0; }
+  act = Math.max(0, Math.min(1, act));
+  const ts = Date.now();
+  return `/dog.svg?mode=${mode}&activity=${act.toFixed(2)}&ts=${ts}`;
+}
+
+function tickClock(){
+  const now = new Date();
+  clock.textContent = now.toLocaleString();
+}
+setInterval(tickClock, 500);
+
+function setCorgi(state, activity){
+  // swap CSS class to animate different states
+  const next = (state || 'idle');
+  corgi.classList.remove('idle','focus','break','alert');
+  corgi.classList.add(next);
+  corgi.src = dogUrl(next, activity);
+  corgi.dataset.mode = next;
+}
+
+async function refreshOnce(){
+  try{
+    const r = await fetch('/api/status');
+    const j = await r.json();
+    const s = j && j.sense ? j.sense : {};
+    const tempValue = s.temperature;
+    const humValue = s.humidity;
+    const presValue = s.pressure;
+    tempEl.textContent = tempValue !== undefined && tempValue !== null && tempValue.toFixed ? tempValue.toFixed(1) : '--';
+    humEl.textContent = humValue !== undefined && humValue !== null && humValue.toFixed ? humValue.toFixed(1) : '--';
+    presEl.textContent = presValue !== undefined && presValue !== null && presValue.toFixed ? presValue.toFixed(1) : '--';
+    senseAvail.textContent = s.available ? 'Sense HAT ✓' : 'Sense HAT unavailable';
+    const motionValue = j && j.motion ? j.motion : [];
+    motionEl.textContent = motionValue.slice(-50).join('\n');
+    const modeText = j && Object.prototype.hasOwnProperty.call(j, 'mode') ? j.mode : undefined;
+    modeEl.textContent = 'Mode: ' + modeText;
+
+    const rawMode = j && j.mode ? j.mode : 'IDLE';
+    const state = rawMode.toLowerCase();
+    const activity = j && j.activity_level !== undefined && j.activity_level !== null ? j.activity_level : 0;
+    setCorgi(state, activity);
+  }catch(e){
+    console.error(e);
+  }
+}
+
+async function initWS(){
+  try{
+    const ws = new WebSocket((location.protocol==='https:'?'wss':'ws')+'://'+location.host+'/ws');
+    ws.onmessage = (ev)=>{
+      const j = JSON.parse(ev.data);
+      if(j && j.kind==='tick'){
+        const s = j.payload ? j.payload : {};
+        const sense = s && s.sense ? s.sense : {};
+        const tempValue = sense.temperature;
+        const humValue = sense.humidity;
+        const presValue = sense.pressure;
+        tempEl.textContent = tempValue !== undefined && tempValue !== null && tempValue.toFixed ? tempValue.toFixed(1) : '--';
+        humEl.textContent = humValue !== undefined && humValue !== null && humValue.toFixed ? humValue.toFixed(1) : '--';
+        presEl.textContent = presValue !== undefined && presValue !== null && presValue.toFixed ? presValue.toFixed(1) : '--';
+        senseAvail.textContent = sense.available ? 'Sense HAT ✓' : 'Sense HAT unavailable';
+        const motionValue = s && s.motion ? s.motion : [];
+        motionEl.textContent = motionValue.slice(-50).join('\n');
+        const modeText = s && Object.prototype.hasOwnProperty.call(s, 'mode') ? s.mode : undefined;
+        modeEl.textContent = 'Mode: ' + modeText;
+        const modeRaw = s && s.mode ? s.mode : 'IDLE';
+        const activity = s && s.activity_level !== undefined && s.activity_level !== null ? s.activity_level : 0;
+        setCorgi(modeRaw.toLowerCase(), activity);
+      }
+    };
+    ws.onclose = ()=> setTimeout(initWS, 2000);
+  }catch(e){
+    console.error('WS init failed', e);
+  }
+}
+
+refreshOnce();
+initWS();

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -8,6 +8,26 @@ const motionEl = document.getElementById('motion');
 const modeEl = document.getElementById('mode');
 const corgi = document.getElementById('corgi');
 
+function isPresent(value){
+  return value !== undefined && value !== null;
+}
+
+function ensureObject(value){
+  return value !== undefined && value !== null && typeof value === 'object' ? value : {};
+}
+
+function ensureArray(value){
+  return Array.isArray(value) ? value : [];
+}
+
+function hasOwn(obj, prop){
+  return Object.prototype.hasOwnProperty.call(obj, prop);
+}
+
+function formatReading(value){
+  return isPresent(value) && typeof value.toFixed === 'function' ? value.toFixed(1) : '--';
+}
+
 function dogUrl(state, activity){
   const modeValue = state !== undefined && state !== null ? state : 'idle';
   const mode = encodeURIComponent(modeValue);
@@ -27,7 +47,7 @@ setInterval(tickClock, 500);
 
 function setCorgi(state, activity){
   // swap CSS class to animate different states
-  const next = (state || 'idle');
+  const next = isPresent(state) ? state : 'idle';
   corgi.classList.remove('idle','focus','break','alert');
   corgi.classList.add(next);
   corgi.src = dogUrl(next, activity);
@@ -38,22 +58,22 @@ async function refreshOnce(){
   try{
     const r = await fetch('/api/status');
     const j = await r.json();
-    const s = j && j.sense ? j.sense : {};
-    const tempValue = s.temperature;
-    const humValue = s.humidity;
-    const presValue = s.pressure;
-    tempEl.textContent = tempValue !== undefined && tempValue !== null && tempValue.toFixed ? tempValue.toFixed(1) : '--';
-    humEl.textContent = humValue !== undefined && humValue !== null && humValue.toFixed ? humValue.toFixed(1) : '--';
-    presEl.textContent = presValue !== undefined && presValue !== null && presValue.toFixed ? presValue.toFixed(1) : '--';
-    senseAvail.textContent = s.available ? 'Sense HAT ✓' : 'Sense HAT unavailable';
-    const motionValue = j && j.motion ? j.motion : [];
+    const status = ensureObject(j);
+    const sense = ensureObject(status.sense);
+    tempEl.textContent = formatReading(sense.temperature);
+    humEl.textContent = formatReading(sense.humidity);
+    presEl.textContent = formatReading(sense.pressure);
+    senseAvail.textContent = sense.available ? 'Sense HAT ✓' : 'Sense HAT unavailable';
+    const motionValue = ensureArray(status.motion);
     motionEl.textContent = motionValue.slice(-50).join('\n');
-    const modeText = j && Object.prototype.hasOwnProperty.call(j, 'mode') ? j.mode : undefined;
+    const modeText = hasOwn(status, 'mode') ? status.mode : undefined;
     modeEl.textContent = 'Mode: ' + modeText;
 
-    const rawMode = j && j.mode ? j.mode : 'IDLE';
-    const state = rawMode.toLowerCase();
-    const activity = j && j.activity_level !== undefined && j.activity_level !== null ? j.activity_level : 0;
+    const rawModeCandidate = status.mode;
+    const rawMode = rawModeCandidate ? rawModeCandidate : 'IDLE';
+    const state = typeof rawMode === 'string' ? rawMode.toLowerCase() : String(rawMode).toLowerCase();
+    const activityCandidate = hasOwn(status, 'activity_level') ? status.activity_level : undefined;
+    const activity = isPresent(activityCandidate) ? activityCandidate : 0;
     setCorgi(state, activity);
   }catch(e){
     console.error(e);
@@ -65,23 +85,24 @@ async function initWS(){
     const ws = new WebSocket((location.protocol==='https:'?'wss':'ws')+'://'+location.host+'/ws');
     ws.onmessage = (ev)=>{
       const j = JSON.parse(ev.data);
-      if(j && j.kind==='tick'){
-        const s = j.payload ? j.payload : {};
-        const sense = s && s.sense ? s.sense : {};
-        const tempValue = sense.temperature;
-        const humValue = sense.humidity;
-        const presValue = sense.pressure;
-        tempEl.textContent = tempValue !== undefined && tempValue !== null && tempValue.toFixed ? tempValue.toFixed(1) : '--';
-        humEl.textContent = humValue !== undefined && humValue !== null && humValue.toFixed ? humValue.toFixed(1) : '--';
-        presEl.textContent = presValue !== undefined && presValue !== null && presValue.toFixed ? presValue.toFixed(1) : '--';
+      const message = ensureObject(j);
+      if(message.kind==='tick'){
+        const payload = ensureObject(message.payload);
+        const sense = ensureObject(payload.sense);
+        tempEl.textContent = formatReading(sense.temperature);
+        humEl.textContent = formatReading(sense.humidity);
+        presEl.textContent = formatReading(sense.pressure);
         senseAvail.textContent = sense.available ? 'Sense HAT ✓' : 'Sense HAT unavailable';
-        const motionValue = s && s.motion ? s.motion : [];
+        const motionValue = ensureArray(payload.motion);
         motionEl.textContent = motionValue.slice(-50).join('\n');
-        const modeText = s && Object.prototype.hasOwnProperty.call(s, 'mode') ? s.mode : undefined;
+        const modeText = hasOwn(payload, 'mode') ? payload.mode : undefined;
         modeEl.textContent = 'Mode: ' + modeText;
-        const modeRaw = s && s.mode ? s.mode : 'IDLE';
-        const activity = s && s.activity_level !== undefined && s.activity_level !== null ? s.activity_level : 0;
-        setCorgi(modeRaw.toLowerCase(), activity);
+        const modeRawCandidate = payload.mode;
+        const modeRaw = modeRawCandidate ? modeRawCandidate : 'IDLE';
+        const modeString = typeof modeRaw === 'string' ? modeRaw : String(modeRaw);
+        const activityCandidate = hasOwn(payload, 'activity_level') ? payload.activity_level : undefined;
+        const activity = isPresent(activityCandidate) ? activityCandidate : 0;
+        setCorgi(modeString.toLowerCase(), activity);
       }
     };
     ws.onclose = ()=> setTimeout(initWS, 2000);

--- a/web/static/styles.css
+++ b/web/static/styles.css
@@ -1,0 +1,40 @@
+
+:root{ --bg:#0b0f14; --panel:#0f1720; --text:#e6edf3; --muted:#9fb0c0; --accent:#3fa9f5; }
+*{ box-sizing:border-box; }
+html,body{ margin:0; height:100%; background:var(--bg); color:var(--text); font-family: system-ui, -apple-system, Segoe UI, Roboto, Inter, Ubuntu, 'Helvetica Neue', Arial, 'Noto Sans', 'Apple Color Emoji', 'Segoe UI Emoji'; }
+.topbar{ display:flex; justify-content:space-between; align-items:center; padding:10px 14px; background:#0c131b; position:sticky; top:0; z-index:10; box-shadow:0 2px 8px rgba(0,0,0,.3) }
+.brand{ font-weight:700; letter-spacing:.3px }
+.clock{ color:var(--muted); font-variant-numeric:tabular-nums }
+.grid{ display:grid; grid-template-columns: repeat(12, 1fr); gap:12px; padding:12px; }
+.panel{ background:var(--panel); border:1px solid #152033; border-radius:14px; padding:12px; box-shadow:0 6px 20px rgba(0,0,0,.25); }
+.corgi-panel{ grid-column: span 4; display:flex; flex-direction:column; align-items:center; justify-content:center; }
+.corgi-panel img{ width:100%; max-width:280px; transition: transform .4s ease; filter: drop-shadow(0 10px 25px rgba(0,0,0,.35)); }
+.corgi-panel img.idle{ transform: translateY(0px); }
+.corgi-panel img.focus{ transform: translateY(-6px) scale(1.02); }
+.corgi-panel img.break{ transform: translateY(2px) scale(.98); filter: grayscale(.2) brightness(.9); }
+.corgi-panel img.alert{ animation: wiggle .18s ease-in-out 0s 8 alternate; }
+@keyframes wiggle{ from{ transform: rotate(-6deg)} to{ transform: rotate(6deg)} }
+.corgi-panel .mode{ margin-top:8px; color:var(--muted) }
+
+.measures{ grid-column: span 3; }
+.measures h3{ margin:2px 0 10px }
+.measure{ display:flex; align-items:baseline; gap:6px; margin:4px 0 }
+.measure b{ font-size:1.3rem }
+.availability{ margin-top:6px; color:var(--muted) }
+
+.camera{ grid-column: span 5; }
+.camera img{ width:100%; border-radius:10px; border:1px solid #1b2940 }
+
+.motion{ grid-column: span 12; }
+.motion pre{ white-space: pre-wrap; max-height: 260px; overflow:auto; color:#cfe3ff; background:#0b1220; padding:10px; border-radius:10px; border:1px solid #152033 }
+
+.foot{ text-align:center; color:var(--muted); padding:8px 0 16px }
+
+/* Compact mode: when small, show only corgi + measures */
+@media (max-width: 680px){
+  .grid{ grid-template-columns: repeat(4, 1fr); }
+  .camera{ display:none }
+  .motion{ display:none }
+  .corgi-panel{ grid-column: span 4; }
+  .measures{ grid-column: span 4; }
+}


### PR DESCRIPTION
## Summary
- rewrite the front-end helpers in WebApp.APP_JS to use explicit null/undefined guards instead of optional chaining and nullish coalescing
- regenerate the static web assets so that app.js mirrors the updated guard logic

## Testing
- node --check web/static/app.js
- python -m compileall WebApp.py

------
https://chatgpt.com/codex/tasks/task_e_68dee70d69b4832f80cd88aca535530b