### PR TITLE
Add official dog mascot asset and update renderer

### DIFF
--- a/web/static/dog.svg
+++ b/web/static/dog.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 320" role="img" aria-label="Dog mascot">
+  <rect id="bg" width="320" height="320" rx="28" fill="#0f1720"/>
+  <g id="dog" transform="translate(40 60)">
+    <g id="ear-left-group" transform="rotate(0 60 40)">
+      <path id="ear-left" d="M14 88 Q60 4 106 66 L86 98 Z" fill="#ffd8b3" stroke="#3d2b1f" stroke-width="4"/>
+    </g>
+    <g id="ear-right-group" transform="translate(120 0) rotate(0 60 40)">
+      <path id="ear-right" d="M14 88 Q60 4 106 66 L86 98 Z" fill="#ffd8b3" stroke="#3d2b1f" stroke-width="4"/>
+    </g>
+    <ellipse id="body" cx="120" cy="160" rx="120" ry="100" fill="#f7b37f" stroke="#3d2b1f" stroke-width="6"/>
+    <ellipse id="belly" cx="120" cy="200" rx="82" ry="60" fill="#fff4e6" opacity="0.95"/>
+    <g id="tail-group" transform="rotate(-12 0 180)">
+      <path id="tail-path" d="M-36 220 Q-60 140 -6 130" fill="none" stroke="#f7b37f" stroke-width="22" stroke-linecap="round"/>
+      <circle id="tail-tip" cx="-8" cy="128" r="18" fill="#fff4e6"/>
+    </g>
+    <ellipse id="eye-left" cx="80" cy="110" rx="20" ry="14" fill="#161616"/>
+    <ellipse id="eye-right" cx="160" cy="110" rx="20" ry="14" fill="#161616"/>
+    <circle id="eye-highlight-left" cx="72" cy="101.6" r="7" fill="#ffffff" opacity="0.6"/>
+    <circle id="eye-highlight-right" cx="152" cy="101.6" r="7" fill="#ffffff" opacity="0.6"/>
+    <circle id="cheek-left" cx="70" cy="180" r="20" fill="#ffceb0" opacity="0.5"/>
+    <circle id="cheek-right" cx="170" cy="180" r="20" fill="#ffceb0" opacity="0.5"/>
+    <rect id="nose" x="92" y="140" width="56" height="26" rx="16" fill="#202020"/>
+    <path id="nose-shadow" d="M104 154 Q120 164 136 154" fill="none" stroke="#000000" stroke-width="3" opacity="0.35"/>
+    <path id="mouth" d="M70 200 Q120 188 170 200" fill="none" stroke="#3d2b1f" stroke-width="6" stroke-linecap="round"/>
+  </g>
+  <g id="label" transform="translate(0 0)">
+    <rect id="label-rect" x="90" y="18" width="140" height="36" rx="18" fill="#3fa9f5" opacity="0.9"/>
+    <text id="label-text" x="160" y="43" font-size="18" text-anchor="middle" font-family="'Nunito','Segoe UI',sans-serif" fill="#04111c">Idle</text>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- add the official dog.svg asset to the repository and ensure it is copied alongside the other generated web files
- update the web UI to load the static mascot initially and reuse the SVG file when rendering reactive variants
- switch the renderer to adjust the official SVG markup via ElementTree so colours and poses stay in sync with mode/activity

## Testing
- python - <<'PY'
import types, sys

class DummyCap:
    def __init__(self, index=0):
        self.index = index
    def isOpened(self):
        return False
    def read(self):
        return False, None

cv2_stub = types.SimpleNamespace(
    VideoCapture=lambda index=0: DummyCap(index),
    imencode=lambda *args, **kwargs: (False, None),
)
sys.modules['cv2'] = cv2_stub

import WebApp

for mode in ['idle', 'focus', 'break', 'alert']:
    svg = WebApp.render_dog_svg(mode, 0.5)
    assert '<svg' in svg and mode.capitalize() in svg, mode
    print(mode, len(svg))
PY

------
https://chatgpt.com/codex/tasks/task_e_68dee8a3bdec832fac1057d9adcda5d8