### PR TITLE
Handle missing cv2 and mode fallbacks

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>pi_productivity</title>
+  <link rel="stylesheet" href="/static/styles.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="brand">🐾 pi_productivity</div>
+    <div class="clock" id="clock"></div>
+  </header>
+
+  <main class="grid">
+    <section class="panel corgi-panel">
+      <img id="corgi" src="/dog.svg?mode=idle" alt="Dog mascot" />
+      <div class="mode" id="mode">Mode: ...</div>
+    </section>
+
+    <section class="panel measures">
+      <h3>Measures</h3>
+      <div class="measure"><span>Temp</span><b id="temp">--</b><span>°C</span></div>
+      <div class="measure"><span>Humidity</span><b id="hum">--</b><span>%</span></div>
+      <div class="measure"><span>Pressure</span><b id="pres">--</b><span>hPa</span></div>
+      <div class="availability" id="senseAvail"></div>
+    </section>
+
+    <section class="panel camera">
+      <h3>Camera</h3>
+      <img id="cam" src="/camera.jpg" alt="Camera" />
+    </section>
+
+    <section class="panel motion">
+      <h3>Motion tasks/events</h3>
+      <pre id="motion"></pre>
+    </section>
+  </main>
+
+  <footer class="foot">Made with FastAPI • Resize window to see compact mode</footer>
+  <script src="/static/app.js"></script>
+</body>
+</html>

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -1,0 +1,118 @@
+
+const clock = document.getElementById('clock');
+const tempEl = document.getElementById('temp');
+const humEl = document.getElementById('hum');
+const presEl = document.getElementById('pres');
+const senseAvail = document.getElementById('senseAvail');
+const motionEl = document.getElementById('motion');
+const modeEl = document.getElementById('mode');
+const corgi = document.getElementById('corgi');
+
+function isPresent(value){
+  return value !== undefined && value !== null;
+}
+
+function ensureObject(value){
+  return value !== undefined && value !== null && typeof value === 'object' ? value : {};
+}
+
+function ensureArray(value){
+  return Array.isArray(value) ? value : [];
+}
+
+function hasOwn(obj, prop){
+  return Object.prototype.hasOwnProperty.call(obj, prop);
+}
+
+function formatReading(value){
+  return isPresent(value) && typeof value.toFixed === 'function' ? value.toFixed(1) : '--';
+}
+
+function dogUrl(state, activity){
+  const modeValue = state !== undefined && state !== null ? state : 'idle';
+  const mode = encodeURIComponent(modeValue);
+  const activityValue = activity !== undefined && activity !== null ? activity : 0;
+  let act = Number(activityValue);
+  if(!Number.isFinite(act)){ act = 0; }
+  act = Math.max(0, Math.min(1, act));
+  const ts = Date.now();
+  return `/dog.svg?mode=${mode}&activity=${act.toFixed(2)}&ts=${ts}`;
+}
+
+function tickClock(){
+  const now = new Date();
+  clock.textContent = now.toLocaleString();
+}
+setInterval(tickClock, 500);
+
+function setCorgi(state, activity){
+  // swap CSS class to animate different states
+  const next = isPresent(state) ? state : 'idle';
+  corgi.classList.remove('idle','focus','break','alert');
+  corgi.classList.add(next);
+  corgi.src = dogUrl(next, activity);
+  corgi.dataset.mode = next;
+}
+
+async function refreshOnce(){
+  try{
+    const r = await fetch('/api/status');
+    const j = await r.json();
+    const status = ensureObject(j);
+    const sense = ensureObject(status.sense);
+    tempEl.textContent = formatReading(sense.temperature);
+    humEl.textContent = formatReading(sense.humidity);
+    presEl.textContent = formatReading(sense.pressure);
+    senseAvail.textContent = sense.available ? 'Sense HAT ✓' : 'Sense HAT unavailable';
+    const motionValue = ensureArray(status.motion);
+    motionEl.textContent = motionValue.slice(-50).join('\n');
+    const modeValue = hasOwn(status, 'mode') ? status.mode : undefined;
+    const displaySource = isPresent(modeValue) ? modeValue : '--';
+    const modeLabel = typeof displaySource === 'string' ? displaySource : String(displaySource);
+    modeEl.textContent = 'Mode: ' + modeLabel;
+
+    const rawModeSource = isPresent(modeValue) ? modeValue : 'IDLE';
+    const rawModeString = typeof rawModeSource === 'string' ? rawModeSource : String(rawModeSource);
+    const state = rawModeString.toLowerCase();
+    const activityCandidate = hasOwn(status, 'activity_level') ? status.activity_level : undefined;
+    const activity = isPresent(activityCandidate) ? activityCandidate : 0;
+    setCorgi(state, activity);
+  }catch(e){
+    console.error(e);
+  }
+}
+
+async function initWS(){
+  try{
+    const ws = new WebSocket((location.protocol==='https:'?'wss':'ws')+'://'+location.host+'/ws');
+    ws.onmessage = (ev)=>{
+      const j = JSON.parse(ev.data);
+      const message = ensureObject(j);
+      if(message.kind==='tick'){
+        const payload = ensureObject(message.payload);
+        const sense = ensureObject(payload.sense);
+        tempEl.textContent = formatReading(sense.temperature);
+        humEl.textContent = formatReading(sense.humidity);
+        presEl.textContent = formatReading(sense.pressure);
+        senseAvail.textContent = sense.available ? 'Sense HAT ✓' : 'Sense HAT unavailable';
+        const motionValue = ensureArray(payload.motion);
+        motionEl.textContent = motionValue.slice(-50).join('\n');
+        const modeValue = hasOwn(payload, 'mode') ? payload.mode : undefined;
+        const displaySource = isPresent(modeValue) ? modeValue : '--';
+        const modeLabel = typeof displaySource === 'string' ? displaySource : String(displaySource);
+        modeEl.textContent = 'Mode: ' + modeLabel;
+        const rawModeSource = isPresent(modeValue) ? modeValue : 'IDLE';
+        const modeString = typeof rawModeSource === 'string' ? rawModeSource : String(rawModeSource);
+        const activityCandidate = hasOwn(payload, 'activity_level') ? payload.activity_level : undefined;
+        const activity = isPresent(activityCandidate) ? activityCandidate : 0;
+        setCorgi(modeString.toLowerCase(), activity);
+      }
+    };
+    ws.onclose = ()=> setTimeout(initWS, 2000);
+  }catch(e){
+    console.error('WS init failed', e);
+  }
+}
+
+refreshOnce();
+initWS();

--- a/web/static/styles.css
+++ b/web/static/styles.css
@@ -1,0 +1,40 @@
+
+:root{ --bg:#0b0f14; --panel:#0f1720; --text:#e6edf3; --muted:#9fb0c0; --accent:#3fa9f5; }
+*{ box-sizing:border-box; }
+html,body{ margin:0; height:100%; background:var(--bg); color:var(--text); font-family: system-ui, -apple-system, Segoe UI, Roboto, Inter, Ubuntu, 'Helvetica Neue', Arial, 'Noto Sans', 'Apple Color Emoji', 'Segoe UI Emoji'; }
+.topbar{ display:flex; justify-content:space-between; align-items:center; padding:10px 14px; background:#0c131b; position:sticky; top:0; z-index:10; box-shadow:0 2px 8px rgba(0,0,0,.3) }
+.brand{ font-weight:700; letter-spacing:.3px }
+.clock{ color:var(--muted); font-variant-numeric:tabular-nums }
+.grid{ display:grid; grid-template-columns: repeat(12, 1fr); gap:12px; padding:12px; }
+.panel{ background:var(--panel); border:1px solid #152033; border-radius:14px; padding:12px; box-shadow:0 6px 20px rgba(0,0,0,.25); }
+.corgi-panel{ grid-column: span 4; display:flex; flex-direction:column; align-items:center; justify-content:center; }
+.corgi-panel img{ width:100%; max-width:280px; transition: transform .4s ease; filter: drop-shadow(0 10px 25px rgba(0,0,0,.35)); }
+.corgi-panel img.idle{ transform: translateY(0px); }
+.corgi-panel img.focus{ transform: translateY(-6px) scale(1.02); }
+.corgi-panel img.break{ transform: translateY(2px) scale(.98); filter: grayscale(.2) brightness(.9); }
+.corgi-panel img.alert{ animation: wiggle .18s ease-in-out 0s 8 alternate; }
+@keyframes wiggle{ from{ transform: rotate(-6deg)} to{ transform: rotate(6deg)} }
+.corgi-panel .mode{ margin-top:8px; color:var(--muted) }
+
+.measures{ grid-column: span 3; }
+.measures h3{ margin:2px 0 10px }
+.measure{ display:flex; align-items:baseline; gap:6px; margin:4px 0 }
+.measure b{ font-size:1.3rem }
+.availability{ margin-top:6px; color:var(--muted) }
+
+.camera{ grid-column: span 5; }
+.camera img{ width:100%; border-radius:10px; border:1px solid #1b2940 }
+
+.motion{ grid-column: span 12; }
+.motion pre{ white-space: pre-wrap; max-height: 260px; overflow:auto; color:#cfe3ff; background:#0b1220; padding:10px; border-radius:10px; border:1px solid #152033 }
+
+.foot{ text-align:center; color:var(--muted); padding:8px 0 16px }
+
+/* Compact mode: when small, show only corgi + measures */
+@media (max-width: 680px){
+  .grid{ grid-template-columns: repeat(4, 1fr); }
+  .camera{ display:none }
+  .motion{ display:none }
+  .corgi-panel{ grid-column: span 4; }
+  .measures{ grid-column: span 4; }
+}


### PR DESCRIPTION
## Summary
- guard the optional OpenCV import so the web assets can be regenerated without camera dependencies
- ensure the mode label falls back to `--` while keeping lowercase state handling for the corgi animation
- regenerate the shipped app.js bundle to mirror the new guard logic

## Testing
- node --check web/static/app.js
- python -m compileall WebApp.py
- python - <<'PY'
from WebApp import ensure_web_assets
ensure_web_assets()
print('ok')
PY

------
https://chatgpt.com/codex/tasks/task_e_68dee70d69b4832f80cd88aca535530b