### PR TITLE
Restore dark dashboard layout

### DIFF
--- a/WebApp.py
+++ b/WebApp.py
@@ -774,35 +774,361 @@ refreshOnce();
 initWS();
 """
 
-STYLES_CSS = """:root{
+STYLES_CSS = """
+:root{
   --bg:#0b0f14;
   --panel:#0f1720;
+  --panel-border:#1b2735;
   --text:#e6edf3;
   --muted:#9fb0c0;
   --accent:#3fa9f5;
   --warn:#ff9a9a;
+  --success:#4fd1c5;
+  --shadow:0 12px 32px rgba(5,11,18,0.45);
 }
 
-*{ box-sizing:border-box; }
-.preset-btn:hover{ background:rgba(63,169,245,0.12); border-color:var(--accent); transform:translateY(-1px); }
-.preset-btn:active{ transform:translateY(0); }
-.preset-btn.active{ background:var(--accent); color:#071019; border-color:var(--accent); box-shadow:0 6px 16px rgba(63,169,245,0.35); }
-.preset-btn:disabled{ opacity:.55; cursor:not-allowed; }
-.preset-status{ min-height:1.2em; font-size:.85rem; color:var(--muted); }
+*{
+  box-sizing:border-box;
+}
+
+html,body{
+  height:100%;
+}
+
+body{
+  margin:0;
+  font-family:'Inter',system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;
+  background:var(--bg);
+  color:var(--text);
+  -webkit-font-smoothing:antialiased;
+  display:flex;
+  flex-direction:column;
+}
+
+main{
+  flex:1;
+  width:100%;
+  max-width:1320px;
+  margin:0 auto;
+  padding:32px 40px 48px;
+  display:flex;
+  flex-direction:column;
+  gap:28px;
+}
+
+.topbar{
+  display:grid;
+  grid-template-columns:auto 1fr auto;
+  align-items:center;
+  gap:20px;
+}
+
+h1,h2,h3,h4,h5{
+  font-weight:600;
+  margin:0;
+  color:var(--text);
+}
+
+h1{
+  font-size:2.25rem;
+}
+
+h2{
+  font-size:1.5rem;
+}
+
+h3{
+  font-size:1.15rem;
+}
+
+p{
+  margin:0;
+  line-height:1.55;
+  color:var(--muted);
+}
+
+.clock{
+  justify-self:end;
+  font-size:1.75rem;
+  font-variant-numeric:tabular-nums;
+  letter-spacing:0.04em;
+}
+
+.mode-pill{
+  padding:10px 18px;
+  border-radius:999px;
+  background:rgba(63,169,245,0.15);
+  color:var(--accent);
+  font-weight:600;
+  text-transform:uppercase;
+  letter-spacing:0.08em;
+  font-size:0.75rem;
+}
+
+.grid{
+  display:grid;
+  grid-template-columns:repeat(6, minmax(0, 1fr));
+  gap:24px;
+}
+
+.panel{
+  background:var(--panel);
+  border:1px solid var(--panel-border);
+  border-radius:18px;
+  padding:22px 24px;
+  box-shadow:var(--shadow);
+  display:flex;
+  flex-direction:column;
+  gap:18px;
+}
+
+.panel-header{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:12px;
+}
+
+.panel-header h2{
+  font-size:1.25rem;
+}
+
+.panel-subtitle{
+  color:var(--muted);
+  font-size:0.9rem;
+}
+
+.measures{
+  grid-column:span 2;
+}
+
+.measures-grid{
+  display:grid;
+  grid-template-columns:repeat(2, minmax(0, 1fr));
+  gap:16px;
+}
+
+.measure{
+  background:rgba(15,23,32,0.55);
+  border:1px solid rgba(159,176,192,0.08);
+  border-radius:12px;
+  padding:14px;
+  display:flex;
+  flex-direction:column;
+  gap:6px;
+}
+
+.measure-label{
+  color:var(--muted);
+  text-transform:uppercase;
+  font-size:0.75rem;
+  letter-spacing:0.08em;
+}
+
+.measure-value{
+  font-size:1.85rem;
+  font-variant-numeric:tabular-nums;
+  font-weight:600;
+}
+
+.measure-trend{
+  font-size:0.85rem;
+  color:var(--success);
+}
+
+.posture{
+  grid-column:span 2;
+}
+
+.camera{
+  grid-column:span 2;
+}
+
+.camera img{
+  width:100%;
+  max-height:320px;
+  object-fit:cover;
+  border-radius:14px;
+  border:1px solid rgba(159,176,192,0.1);
+  display:block;
+}
+
+.tasks{
+  grid-column:span 3;
+}
+
+.motion{
+  grid-column:span 3;
+}
+
+.event-list{
+  list-style:none;
+  margin:0;
+  padding:0;
+  display:flex;
+  flex-direction:column;
+  gap:14px;
+}
+
+.event-item{
+  display:flex;
+  align-items:flex-start;
+  justify-content:space-between;
+  gap:16px;
+  padding:14px 16px;
+  background:rgba(11,15,20,0.75);
+  border:1px solid rgba(27,39,53,0.8);
+  border-radius:12px;
+}
+
+.event-item time{
+  font-variant-numeric:tabular-nums;
+  color:var(--muted);
+  font-size:0.9rem;
+}
+
+.event-item strong{
+  font-size:1rem;
+  color:var(--text);
+}
+
+.event-meta{
+  color:var(--muted);
+  font-size:0.85rem;
+}
+
+.preset-controls{
+  display:flex;
+  flex-wrap:wrap;
+  gap:10px;
+}
+
+.preset-btn{
+  padding:10px 16px;
+  border-radius:999px;
+  border:1px solid rgba(63,169,245,0.5);
+  background:transparent;
+  color:var(--accent);
+  font-weight:600;
+  cursor:pointer;
+  transition:all 0.2s ease;
+}
+
+.preset-btn:hover{
+  background:rgba(63,169,245,0.12);
+  border-color:var(--accent);
+  transform:translateY(-1px);
+}
+
+.preset-btn:active{
+  transform:translateY(0);
+}
+
+.preset-btn.active{
+  background:var(--accent);
+  color:#071019;
+  border-color:var(--accent);
+  box-shadow:0 6px 16px rgba(63,169,245,0.35);
+}
+
+.preset-btn:disabled{
+  opacity:.55;
+  cursor:not-allowed;
+}
+
+.preset-status{
+  min-height:1.2em;
+  font-size:.85rem;
+  color:var(--muted);
+}
+
+.footer{
+  margin-top:auto;
+  padding:32px 40px;
+  color:var(--muted);
+  font-size:0.85rem;
+  display:flex;
+  justify-content:space-between;
+  align-items:center;
+  gap:16px;
+  border-top:1px solid rgba(27,39,53,0.7);
+}
+
+.footer a{
+  color:var(--accent);
+  text-decoration:none;
+}
+
+.footer a:hover{
+  text-decoration:underline;
+}
+
+@media (max-width: 1024px){
+  main{
+    padding:28px 24px 36px;
+  }
+
+  .grid{
+    grid-template-columns:repeat(4, minmax(0, 1fr));
+  }
+
+  .measures,
+  .posture,
+  .camera{
+    grid-column:span 2;
+  }
+
+  .tasks,
+  .motion{
+    grid-column:span 4;
+  }
 }
 
 @media (max-width: 720px){
-  .topbar{ grid-template-columns:1fr; text-align:center; }
-  .mode-pill{ justify-self:center; }
-  .clock{ justify-self:center; }
-  .grid{ grid-template-columns:repeat(4, 1fr); padding:12px; }
-  .mode-panel{ grid-column:span 4; }
-  .measures{ grid-column:span 4; }
-  .posture{ grid-column:span 4; }
-  .camera{ grid-column:span 4; }
-  .tasks{ grid-column:span 4; }
-  .motion{ grid-column:span 4; }
-  .preset-btn{ flex:1 1 100%; }
+  main{
+    padding:24px 18px 32px;
+  }
+
+  .topbar{
+    grid-template-columns:1fr;
+    text-align:center;
+  }
+
+  .mode-pill{
+    justify-self:center;
+  }
+
+  .clock{
+    justify-self:center;
+  }
+
+  .grid{
+    grid-template-columns:repeat(4, 1fr);
+    padding:12px;
+  }
+
+  .panel{
+    padding:18px;
+  }
+
+  .mode-panel,
+  .measures,
+  .posture,
+  .camera,
+  .tasks,
+  .motion{
+    grid-column:span 4;
+  }
+
+  .preset-btn{
+    flex:1 1 100%;
+  }
+
+  .footer{
+    padding:24px 18px;
+    flex-direction:column;
+    text-align:center;
+  }
 }
 """
 

--- a/web/static/styles.css
+++ b/web/static/styles.css
@@ -1,30 +1,355 @@
 :root{
   --bg:#0b0f14;
   --panel:#0f1720;
+  --panel-border:#1b2735;
   --text:#e6edf3;
   --muted:#9fb0c0;
   --accent:#3fa9f5;
   --warn:#ff9a9a;
+  --success:#4fd1c5;
+  --shadow:0 12px 32px rgba(5,11,18,0.45);
 }
 
-*{ box-sizing:border-box; }
-.preset-btn:hover{ background:rgba(63,169,245,0.12); border-color:var(--accent); transform:translateY(-1px); }
-.preset-btn:active{ transform:translateY(0); }
-.preset-btn.active{ background:var(--accent); color:#071019; border-color:var(--accent); box-shadow:0 6px 16px rgba(63,169,245,0.35); }
-.preset-btn:disabled{ opacity:.55; cursor:not-allowed; }
-.preset-status{ min-height:1.2em; font-size:.85rem; color:var(--muted); }
+*{
+  box-sizing:border-box;
+}
+
+html,body{
+  height:100%;
+}
+
+body{
+  margin:0;
+  font-family:'Inter',system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;
+  background:var(--bg);
+  color:var(--text);
+  -webkit-font-smoothing:antialiased;
+  display:flex;
+  flex-direction:column;
+}
+
+main{
+  flex:1;
+  width:100%;
+  max-width:1320px;
+  margin:0 auto;
+  padding:32px 40px 48px;
+  display:flex;
+  flex-direction:column;
+  gap:28px;
+}
+
+.topbar{
+  display:grid;
+  grid-template-columns:auto 1fr auto;
+  align-items:center;
+  gap:20px;
+}
+
+h1,h2,h3,h4,h5{
+  font-weight:600;
+  margin:0;
+  color:var(--text);
+}
+
+h1{
+  font-size:2.25rem;
+}
+
+h2{
+  font-size:1.5rem;
+}
+
+h3{
+  font-size:1.15rem;
+}
+
+p{
+  margin:0;
+  line-height:1.55;
+  color:var(--muted);
+}
+
+.clock{
+  justify-self:end;
+  font-size:1.75rem;
+  font-variant-numeric:tabular-nums;
+  letter-spacing:0.04em;
+}
+
+.mode-pill{
+  padding:10px 18px;
+  border-radius:999px;
+  background:rgba(63,169,245,0.15);
+  color:var(--accent);
+  font-weight:600;
+  text-transform:uppercase;
+  letter-spacing:0.08em;
+  font-size:0.75rem;
+}
+
+.grid{
+  display:grid;
+  grid-template-columns:repeat(6, minmax(0, 1fr));
+  gap:24px;
+}
+
+.panel{
+  background:var(--panel);
+  border:1px solid var(--panel-border);
+  border-radius:18px;
+  padding:22px 24px;
+  box-shadow:var(--shadow);
+  display:flex;
+  flex-direction:column;
+  gap:18px;
+}
+
+.panel-header{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:12px;
+}
+
+.panel-header h2{
+  font-size:1.25rem;
+}
+
+.panel-subtitle{
+  color:var(--muted);
+  font-size:0.9rem;
+}
+
+.measures{
+  grid-column:span 2;
+}
+
+.measures-grid{
+  display:grid;
+  grid-template-columns:repeat(2, minmax(0, 1fr));
+  gap:16px;
+}
+
+.measure{
+  background:rgba(15,23,32,0.55);
+  border:1px solid rgba(159,176,192,0.08);
+  border-radius:12px;
+  padding:14px;
+  display:flex;
+  flex-direction:column;
+  gap:6px;
+}
+
+.measure-label{
+  color:var(--muted);
+  text-transform:uppercase;
+  font-size:0.75rem;
+  letter-spacing:0.08em;
+}
+
+.measure-value{
+  font-size:1.85rem;
+  font-variant-numeric:tabular-nums;
+  font-weight:600;
+}
+
+.measure-trend{
+  font-size:0.85rem;
+  color:var(--success);
+}
+
+.posture{
+  grid-column:span 2;
+}
+
+.camera{
+  grid-column:span 2;
+}
+
+.camera img{
+  width:100%;
+  max-height:320px;
+  object-fit:cover;
+  border-radius:14px;
+  border:1px solid rgba(159,176,192,0.1);
+  display:block;
+}
+
+.tasks{
+  grid-column:span 3;
+}
+
+.motion{
+  grid-column:span 3;
+}
+
+.event-list{
+  list-style:none;
+  margin:0;
+  padding:0;
+  display:flex;
+  flex-direction:column;
+  gap:14px;
+}
+
+.event-item{
+  display:flex;
+  align-items:flex-start;
+  justify-content:space-between;
+  gap:16px;
+  padding:14px 16px;
+  background:rgba(11,15,20,0.75);
+  border:1px solid rgba(27,39,53,0.8);
+  border-radius:12px;
+}
+
+.event-item time{
+  font-variant-numeric:tabular-nums;
+  color:var(--muted);
+  font-size:0.9rem;
+}
+
+.event-item strong{
+  font-size:1rem;
+  color:var(--text);
+}
+
+.event-meta{
+  color:var(--muted);
+  font-size:0.85rem;
+}
+
+.preset-controls{
+  display:flex;
+  flex-wrap:wrap;
+  gap:10px;
+}
+
+.preset-btn{
+  padding:10px 16px;
+  border-radius:999px;
+  border:1px solid rgba(63,169,245,0.5);
+  background:transparent;
+  color:var(--accent);
+  font-weight:600;
+  cursor:pointer;
+  transition:all 0.2s ease;
+}
+
+.preset-btn:hover{
+  background:rgba(63,169,245,0.12);
+  border-color:var(--accent);
+  transform:translateY(-1px);
+}
+
+.preset-btn:active{
+  transform:translateY(0);
+}
+
+.preset-btn.active{
+  background:var(--accent);
+  color:#071019;
+  border-color:var(--accent);
+  box-shadow:0 6px 16px rgba(63,169,245,0.35);
+}
+
+.preset-btn:disabled{
+  opacity:.55;
+  cursor:not-allowed;
+}
+
+.preset-status{
+  min-height:1.2em;
+  font-size:.85rem;
+  color:var(--muted);
+}
+
+.footer{
+  margin-top:auto;
+  padding:32px 40px;
+  color:var(--muted);
+  font-size:0.85rem;
+  display:flex;
+  justify-content:space-between;
+  align-items:center;
+  gap:16px;
+  border-top:1px solid rgba(27,39,53,0.7);
+}
+
+.footer a{
+  color:var(--accent);
+  text-decoration:none;
+}
+
+.footer a:hover{
+  text-decoration:underline;
+}
+
+@media (max-width: 1024px){
+  main{
+    padding:28px 24px 36px;
+  }
+
+  .grid{
+    grid-template-columns:repeat(4, minmax(0, 1fr));
+  }
+
+  .measures,
+  .posture,
+  .camera{
+    grid-column:span 2;
+  }
+
+  .tasks,
+  .motion{
+    grid-column:span 4;
+  }
 }
 
 @media (max-width: 720px){
-  .topbar{ grid-template-columns:1fr; text-align:center; }
-  .mode-pill{ justify-self:center; }
-  .clock{ justify-self:center; }
-  .grid{ grid-template-columns:repeat(4, 1fr); padding:12px; }
-  .mode-panel{ grid-column:span 4; }
-  .measures{ grid-column:span 4; }
-  .posture{ grid-column:span 4; }
-  .camera{ grid-column:span 4; }
-  .tasks{ grid-column:span 4; }
-  .motion{ grid-column:span 4; }
-  .preset-btn{ flex:1 1 100%; }
+  main{
+    padding:24px 18px 32px;
+  }
+
+  .topbar{
+    grid-template-columns:1fr;
+    text-align:center;
+  }
+
+  .mode-pill{
+    justify-self:center;
+  }
+
+  .clock{
+    justify-self:center;
+  }
+
+  .grid{
+    grid-template-columns:repeat(4, 1fr);
+    padding:12px;
+  }
+
+  .panel{
+    padding:18px;
+  }
+
+  .mode-panel,
+  .measures,
+  .posture,
+  .camera,
+  .tasks,
+  .motion{
+    grid-column:span 4;
+  }
+
+  .preset-btn{
+    flex:1 1 100%;
+  }
+
+  .footer{
+    padding:24px 18px;
+    flex-direction:column;
+    text-align:center;
+  }
 }


### PR DESCRIPTION
## Summary
- restore the dashboard's dark theme layout, grid, and typography rules in the stylesheet
- mirror the same dark theme styles in the embedded `STYLES_CSS` fallback used when regenerating assets

## Testing
- Manually reloaded the dashboard at http://127.0.0.1:8090 to verify the dark card layout

------
https://chatgpt.com/codex/tasks/task_e_68e0be6a0aec832fa641e25ab6f5374f