### PR TITLE
Connect e-paper display to task database

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pi Productivity – Guia rápido para Raspberry Pi
 
-Automatize postura, OCR de anotações e lembretes de hidratação usando Raspberry Pi 5, Sense HAT e câmera oficial. O projeto também pode integrar um display e-paper no futuro.
+Automatize postura, OCR de anotações e lembretes de hidratação usando Raspberry Pi 5, Sense HAT e câmera oficial. O projeto também integra um display e-paper opcional para mostrar tarefas sincronizadas em um banco SQLite local.
 
 ## Antes de começar
 - Raspberry Pi 5 (8 GB) com Raspberry Pi OS (Debian 12 Bookworm) atualizado.
@@ -142,14 +142,21 @@ api=os.getenv("MOTION_API_KEY")
 print(requests.get("https://api.usemotion.com/v1/tasks",
                    headers={"X-API-Key": api}, timeout=15).status_code)
 PY
-10. Próximos passos (opcional)
-Quando o display e-paper chegar, será possível:
+10. Display e-paper opcional
+Com o display Waveshare 1,53" conectado via SPI:
 
-Ver tarefas do dia com prazos no painel.
+```
+source ~/pi_productivity/.venv/bin/activate
+python epaper_display.py --limit 6
+```
 
-Usar o modo TAREFAS para atualizar o e-paper.
+O script lê tarefas do banco `~/pi_productivity/data/tasks.db`. O banco é atualizado automaticamente a cada alguns minutos (valor ajustável por `MOTION_SYNC_INTERVAL_SEC`) sempre que o app principal consegue acessar a Motion API. Caso queira rodar manualmente, você pode popular o banco via `TaskDatabase` ou inserir tarefas diretamente na tabela `tasks`.
 
-Usar o joystick (⬅️) como atalho para renovar o painel.
+Para personalizar:
+
+- `EPAPER_ENABLE=0` desativa as atualizações automáticas.
+- `EPAPER_ROTATE_180=1` gira a renderização quando o display estiver invertido.
+- `EPAPER_OUTPUT_PATH` muda o arquivo PNG gerado (padrão `/mnt/data/pi_productivity/last_epaper.png`).
 
 11. Comandos úteis do dia a dia
 bash

--- a/env.example
+++ b/env.example
@@ -16,3 +16,12 @@ HYDRATE_INTERVAL_MIN=40
 HYDRATE_FLASHES=6
 HYDRATE_ON_SEC=0.25
 HYDRATE_OFF_SEC=0.15
+
+# --------- E-paper / tarefas ----------
+EPAPER_ENABLE=1
+EPAPER_ROTATE_180=0
+MOTION_SYNC_INTERVAL_SEC=300
+# opcional: caminho para o banco SQLite com tarefas (default: ~/pi_productivity/data/tasks.db)
+# PI_PRODUCTIVITY_DB=/home/pi/pi_productivity/data/tasks.db
+# opcional: sobrescreve o arquivo PNG salvo
+# EPAPER_OUTPUT_PATH=/mnt/data/pi_productivity/last_epaper.png

--- a/epaper_display.py
+++ b/epaper_display.py
@@ -1,11 +1,30 @@
+"""Helpers to render content on the Waveshare e-paper display.
+
+The class is purposely lightweight so it can also be used in unit tests
+or when running on a machine without the hardware attached.  When no
+physical display is detected the generated PNG is written to
+``/mnt/data/pi_productivity/last_epaper.png`` by default so the caller
+can inspect the output.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+from typing import Dict, List, Sequence
 
 from PIL import Image, ImageDraw, ImageFont
-from typing import List, Dict
-import os
+
+from task_database import TaskDatabase
 
 EPD_W, EPD_H = 200, 200
+DEFAULT_OUTPUT_PATH = Path(
+    os.getenv("EPAPER_OUTPUT_PATH", "/mnt/data/pi_productivity/last_epaper.png")
+).expanduser()
 
-def load_font(size=14):
+
+def load_font(size: int = 14) -> ImageFont.FreeTypeFont:
     for path in [
         "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
         "/usr/share/fonts/truetype/freefont/FreeMono.ttf",
@@ -13,58 +32,107 @@ def load_font(size=14):
         if os.path.exists(path):
             try:
                 return ImageFont.truetype(path, size)
-            except Exception:
-                pass
+            except Exception:  # noqa: BLE001
+                continue
     return ImageFont.load_default()
 
+
 class EPaperDisplay:
-    def __init__(self, rotate_180=False):
+    def __init__(self, rotate_180: bool = False, output_path: Path | str | None = None):
         self.rotate_180 = rotate_180
         self.font = load_font(14)
         self.font_small = load_font(12)
+        self.output_path = Path(output_path).expanduser() if output_path else DEFAULT_OUTPUT_PATH
 
-    def render_list(self, items: List[Dict[str,str]], title="Tarefas do Dia"):
+    # ------------------------------------------------------------------
+    # Rendering helpers
+    # ------------------------------------------------------------------
+    def render_list(self, items: Sequence[Dict[str, str]], title: str = "Tarefas do Dia") -> Path:
         img = Image.new("1", (EPD_W, EPD_H), 1)
-        d = ImageDraw.Draw(img)
+        draw = ImageDraw.Draw(img)
         y = 4
-        d.text((6, y), title[:20], font=self.font, fill=0); y += 18
-        d.line((6, y, EPD_W-6, y), fill=0); y += 4
-        for it in items[:6]:
-            left = it.get("title","")
-            right = it.get("right","")
-            sub = it.get("subtitle","")
-            d.text((6, y), left, font=self.font_small, fill=0)
+        draw.text((6, y), title[:20], font=self.font, fill=0)
+        y += 18
+        draw.line((6, y, EPD_W - 6, y), fill=0)
+        y += 4
+        for item in list(items)[:6]:
+            left = str(item.get("title", ""))
+            right = str(item.get("right", ""))
+            subtitle = str(item.get("subtitle", ""))
+            draw.text((6, y), left[:22], font=self.font_small, fill=0)
             if right:
-                w = d.textlength(right, font=self.font_small)
-                d.text((EPD_W-6-w, y), right, font=self.font_small, fill=0)
+                width = draw.textlength(right, font=self.font_small)
+                draw.text((EPD_W - 6 - width, y), right[:10], font=self.font_small, fill=0)
             y += 14
-            if sub:
-                d.text((10, y), f"• {sub}", font=self.font_small, fill=0)
+            if subtitle:
+                draw.text((10, y), f"• {subtitle[:24]}", font=self.font_small, fill=0)
                 y += 12
             y += 2
         return self.push_to_hardware(img)
 
-    def render_tip(self, tip:str, title="Estudo (TDAH)"):
-        img = Image.new("1",(EPD_W,EPD_H),1)
-        d = ImageDraw.Draw(img)
-        y=4
-        d.text((6,y), title[:20], font=self.font, fill=0); y+=18
-        d.line((6,y,EPD_W-6,y), fill=0); y+=6
-        wrap = []
+    def render_tip(self, tip: str, title: str = "Estudo (TDAH)") -> Path:
+        img = Image.new("1", (EPD_W, EPD_H), 1)
+        draw = ImageDraw.Draw(img)
+        y = 4
+        draw.text((6, y), title[:20], font=self.font, fill=0)
+        y += 18
+        draw.line((6, y, EPD_W - 6, y), fill=0)
+        y += 6
+        wrap: List[str] = []
         line = ""
         for word in tip.split():
-            if len(line)+len(word)+1 > 22:
-                wrap.append(line); line=word
+            if len(line) + len(word) + 1 > 22:
+                wrap.append(line)
+                line = word
             else:
-                line = (line+" "+word).strip()
-        if line: wrap.append(line)
-        for l in wrap[:10]:
-            d.text((8,y), l, font=self.font_small, fill=0); y+=14
+                line = (line + " " + word).strip()
+        if line:
+            wrap.append(line)
+        for entry in wrap[:10]:
+            draw.text((8, y), entry, font=self.font_small, fill=0)
+            y += 14
         return self.push_to_hardware(img)
 
-    def push_to_hardware(self, image):
+    def render_tasks_from_database(
+        self,
+        db_path: Path | str | None = None,
+        title: str = "Tarefas do Dia",
+        limit: int = 6,
+    ) -> Path:
+        database = TaskDatabase(db_path)
+        items = database.fetch_items_for_display(limit=limit)
+        return self.render_list(items, title=title)
+
+    # ------------------------------------------------------------------
+    # Output helper
+    # ------------------------------------------------------------------
+    def push_to_hardware(self, image: Image.Image) -> Path:
         if self.rotate_180:
             image = image.rotate(180)
-        out = "/mnt/data/pi_productivity/last_epaper.png"
-        image.save(out)
-        return out
+        output = self.output_path
+        output.parent.mkdir(parents=True, exist_ok=True)
+        image.save(output)
+        return output
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Atualiza o display e-paper com dados do banco de tarefas.")
+    parser.add_argument("--db", dest="db_path", help="Caminho para o banco SQLite", default=None)
+    parser.add_argument("--title", dest="title", help="Título mostrado no display", default="Tarefas do Dia")
+    parser.add_argument("--limit", dest="limit", type=int, default=6, help="Número máximo de itens exibidos")
+    parser.add_argument("--rotate-180", dest="rotate", action="store_true", help="Gira a imagem 180° antes de salvar")
+    parser.add_argument(
+        "--output",
+        dest="output",
+        default=None,
+        help="Sobrescreve o caminho padrão do arquivo PNG gerado",
+    )
+    args = parser.parse_args()
+
+    display = EPaperDisplay(rotate_180=args.rotate, output_path=args.output)
+    path = display.render_tasks_from_database(db_path=args.db_path, title=args.title, limit=args.limit)
+    print(path)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/task_database.py
+++ b/task_database.py
@@ -1,0 +1,272 @@
+"""Utilities to persist task data for the e-paper display.
+
+The Raspberry Pi setup does not have a database yet.  This module
+creates a small SQLite database with a single ``tasks`` table and
+provides helpers for synchronising Motion tasks and reading a compact
+summary for the e-paper widget.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+from datetime import date, datetime
+from pathlib import Path
+from typing import Iterable, List, Mapping, Sequence
+
+_DEFAULT_DB_PATH = Path(
+    os.getenv("PI_PRODUCTIVITY_DB", "~/pi_productivity/data/tasks.db")
+).expanduser()
+
+
+def _ensure_parent(path: Path) -> None:
+    """Create the parent directory for *path* if it does not exist."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+class TaskDatabase:
+    """Wrapper around the SQLite file used by the project."""
+
+    def __init__(self, db_path: Path | str | None = None):
+        self.path = Path(db_path).expanduser() if db_path else _DEFAULT_DB_PATH
+        _ensure_parent(self.path)
+        self._initialise()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.path)
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _initialise(self) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS tasks (
+                    task_id TEXT PRIMARY KEY,
+                    title TEXT NOT NULL,
+                    subtitle TEXT,
+                    due_date TEXT,
+                    status TEXT,
+                    raw JSON,
+                    updated_at TEXT NOT NULL
+                )
+                """
+            )
+
+    # ------------------------------------------------------------------
+    # Synchronisation helpers
+    # ------------------------------------------------------------------
+    def upsert_motion_tasks(self, tasks: Sequence[Mapping[str, object]]) -> int:
+        """Store/refresh tasks coming from the Motion API.
+
+        ``MotionClient`` returns a list of dictionaries.  Their shape may
+        change over time, so we keep the raw payload while extracting a
+        few common fields that are useful for the e-paper panel.
+        """
+
+        now = datetime.utcnow().isoformat(timespec="seconds")
+        normalised = [self._normalise_task(t, now) for t in tasks]
+        if not normalised:
+            return 0
+        with self._connect() as conn:
+            conn.executemany(
+                """
+                INSERT INTO tasks (task_id, title, subtitle, due_date, status, raw, updated_at)
+                VALUES (:task_id, :title, :subtitle, :due_date, :status, :raw, :updated_at)
+                ON CONFLICT(task_id) DO UPDATE SET
+                    title = excluded.title,
+                    subtitle = excluded.subtitle,
+                    due_date = excluded.due_date,
+                    status = excluded.status,
+                    raw = excluded.raw,
+                    updated_at = excluded.updated_at
+                """,
+                normalised,
+            )
+        return len(normalised)
+
+    def _normalise_task(self, payload: Mapping[str, object], updated_at: str) -> Mapping[str, object]:
+        get = payload.get
+        task_id = get("id") or get("taskId") or get("uid") or get("_id")
+        if task_id is None:
+            task_id = hash(json.dumps(payload, sort_keys=True))
+        task_id = str(task_id)
+
+        title = (
+            get("name")
+            or get("title")
+            or get("summary")
+            or get("description")
+            or "Tarefa sem nome"
+        )
+        title = str(title).strip() or "Tarefa sem nome"
+
+        subtitle = self._extract_subtitle(payload)
+
+        raw_due = (
+            get("dueDate")
+            or get("due")
+            or get("due_date")
+            or get("deadline")
+            or get("end")
+        )
+        due_date = self._normalise_due(raw_due)
+
+        status = (
+            get("status")
+            or ("completed" if bool(get("completed")) else "pending")
+            or "pending"
+        )
+        status = str(status)
+
+        return {
+            "task_id": task_id,
+            "title": title,
+            "subtitle": subtitle,
+            "due_date": due_date,
+            "status": status,
+            "raw": json.dumps(payload, ensure_ascii=False, default=str),
+            "updated_at": updated_at,
+        }
+
+    @staticmethod
+    def _extract_subtitle(payload: Mapping[str, object]) -> str:
+        def _stringify(value: object) -> str:
+            return str(value).strip()
+
+        labels = payload.get("labels") or payload.get("labelNames")
+        if isinstance(labels, Iterable) and not isinstance(labels, (str, bytes, dict)):
+            clean = [
+                _stringify(lbl)
+                for lbl in labels
+                if _stringify(lbl)
+            ]
+            if clean:
+                return ", ".join(clean[:3])
+        if labels:
+            return _stringify(labels)
+
+        description = payload.get("description") or payload.get("note")
+        if isinstance(description, str):
+            first_line = description.strip().splitlines()[0]
+            if first_line:
+                return first_line[:60]
+
+        project = payload.get("projectName") or payload.get("project")
+        if project:
+            return _stringify(project)
+
+        return ""
+
+    @staticmethod
+    def _normalise_due(value: object | None) -> str | None:
+        if value is None:
+            return None
+        if isinstance(value, (int, float)):
+            try:
+                return datetime.fromtimestamp(float(value)).isoformat(timespec="seconds")
+            except Exception:  # noqa: BLE001
+                return None
+        if isinstance(value, str):
+            candidate = value.strip()
+            if not candidate:
+                return None
+            candidate = candidate.replace("Z", "+00:00")
+            for fmt in (None, "%Y-%m-%d"):
+                try:
+                    if fmt:
+                        dt = datetime.strptime(candidate[:10], fmt)
+                    else:
+                        dt = datetime.fromisoformat(candidate)
+                    return dt.isoformat(timespec="seconds")
+                except Exception:  # noqa: BLE001
+                    continue
+        return None
+
+    # ------------------------------------------------------------------
+    # Query helpers
+    # ------------------------------------------------------------------
+    def fetch_items_for_display(self, limit: int = 6) -> List[dict]:
+        """Return a list of simplified entries for the e-paper display."""
+
+        today = date.today()
+        try:
+            with self._connect() as conn:
+                rows = conn.execute(
+                    """
+                    SELECT task_id, title, subtitle, due_date, status
+                    FROM tasks
+                    WHERE COALESCE(LOWER(status), 'pending') NOT IN ('completed', 'done', 'cancelled', 'canceled', 'archived')
+                    ORDER BY
+                        CASE WHEN due_date IS NULL THEN 1 ELSE 0 END,
+                        due_date ASC,
+                        updated_at DESC
+                    LIMIT ?
+                    """,
+                    (limit,),
+                ).fetchall()
+        except sqlite3.Error as exc:
+            return [
+                {
+                    "title": "Erro ao ler tarefas",
+                    "subtitle": str(exc),
+                    "right": "",
+                }
+            ]
+
+        if not rows:
+            return [
+                {
+                    "title": "Sem tarefas pendentes",
+                    "subtitle": "Aproveite para descansar!",
+                    "right": "",
+                }
+            ]
+
+        items: List[dict] = []
+        for row in rows:
+            due_display = self._format_due(row["due_date"], today)
+            subtitle = row["subtitle"] or ""
+            status = (row["status"] or "").lower()
+            if status and status not in {"pending", "open", "todo"}:
+                tag = status.upper()
+                subtitle = f"{subtitle} [{tag}]".strip()
+            items.append(
+                {
+                    "title": row["title"],
+                    "subtitle": subtitle,
+                    "right": due_display,
+                }
+            )
+        return items
+
+    @staticmethod
+    def _format_due(value: str | None, today: date) -> str:
+        if not value:
+            return ""
+        try:
+            dt = datetime.fromisoformat(value)
+        except Exception:  # noqa: BLE001
+            return value[:10]
+        due_date = dt.date()
+        if due_date == today:
+            return "HOJE"
+        if due_date < today:
+            delta = (today - due_date).days
+            if delta == 1:
+                return "Ontem"
+            return f"-{delta}d"
+        delta = (due_date - today).days
+        if delta == 0:
+            return "HOJE"
+        if delta == 1:
+            return "Amanhã"
+        if delta <= 7:
+            return f"{dt.strftime('%a')}"
+        return dt.strftime("%d/%m")
+
+
+__all__ = ["TaskDatabase"]


### PR DESCRIPTION
## Summary
- add a TaskDatabase helper backed by SQLite to persist Motion task snapshots
- update the e-paper renderer to pull items from the database and expose a CLI entry point
- wire the main loop to sync tasks, refresh the display periodically, and document the new environment flags

## Testing
- python -m compileall task_database.py epaper_display.py main.py
- python - <<'PY'
from pathlib import Path
from task_database import TaskDatabase
from epaper_display import EPaperDisplay

path = Path('/tmp/test_tasks.db')
if path.exists():
    path.unlink()

db = TaskDatabase(path)
db.upsert_motion_tasks([
    {'id': '1', 'name': 'Planejar sprint', 'labels': ['Hapvida'], 'dueDate': '2024-05-20T10:00:00Z'},
    {'id': '2', 'name': 'Revisar contratos', 'labels': ['Care Plus'], 'dueDate': '2024-05-18'},
    {'id': '3', 'name': 'Estudar IA', 'description': 'Ler capítulo 3', 'dueDate': None},
])

items = db.fetch_items_for_display()
print('Items:', items)

display = EPaperDisplay(output_path='/tmp/test_epaper.png')
print('Output file:', display.render_tasks_from_database(path))
print('Exists?', Path('/tmp/test_epaper.png').exists())
PY

------
https://chatgpt.com/codex/tasks/task_e_68e0bf660d44832faf8e92044a6f4444